### PR TITLE
fix: add help option to generate.sh script

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -3,7 +3,7 @@
 set -eu
 set -o pipefail
 
-if [ -z "${1:-}" ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
     echo "Usage: $0 <path_to_resources.pkl>"
     echo ""
     echo "Generate idempotent Bash scripts from Pkl resource definitions."
@@ -11,7 +11,12 @@ if [ -z "${1:-}" ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
     echo "Example:"
     echo "  $0 resources.pkl > deploy.sh"
     echo "  bash deploy.sh check"
-    exit $([ "$1" = "--help" ] || [ "$1" = "-h" ] && echo 0 || echo 1)
+    exit 0
+fi
+
+if [ -z "${1:-}" ]; then
+    echo "Usage: $0 <path_to_resources.pkl>"
+    exit 1
 fi
 
 declix_bash_home=$(dirname "$(realpath "$0")")


### PR DESCRIPTION
## Summary

Add proper help functionality to the generate.sh script with correct exit codes.

## Changes

- Support `--help` and `-h` flags to display usage information
- Show usage examples in help text
- Use safer parameter expansion (`${1:-}`) to avoid unbound variable errors
- Exit with code 0 for help requests, 1 for missing arguments

## Benefits

- Better user experience with standard help flags
- Clearer usage instructions with examples
- Proper exit codes following Unix conventions
- Prevents script errors when no arguments provided

## Testing

```bash
./generate.sh --help  # Should show help and exit 0
./generate.sh -h      # Should show help and exit 0
./generate.sh         # Should show usage and exit 1
```

## Release Impact

This fix will trigger a patch release (1.5.1) which will allow us to verify the new release notes format with podman-first instructions.

🤖 Generated with [Claude Code](https://claude.ai/code)